### PR TITLE
Allows doctrine 2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": ">=7.1",
         "symfony/framework-bundle": "~3.4.0",
-        "doctrine/orm": "~2.5.0",
+        "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "~1.2",
         "kitpages/data-grid-bundle": "~3.0",
         "symfony/event-dispatcher": "~3.4.0"


### PR DESCRIPTION
For Symfony 3.4 and beyond it needs to allows Doctrine 2.6.x